### PR TITLE
Ignore string after ')' at :function line (fix #2)

### DIFF
--- a/autoload/vmock/function_define.vim
+++ b/autoload/vmock/function_define.vim
@@ -87,7 +87,7 @@ endfunction
 "  'function FooFunc(first)'         -> ['first']
 "  'function FooFunc(first, second)' -> ['first', 'second']
 function! s:get_arg_names(define_lines)
-  let args = substitute(a:define_lines[0], ".*function.*(\\(.*\\))", '\1', '')
+  let args = matchstr(a:define_lines[0], 'function[^(]\+(\zs[^)]\+\ze)')
   return split(args, ', ')
 endfunction
 


### PR DESCRIPTION
#2 を修正しました。

`:function (...)` の後には`abort`の他にも`dict`が付く場合もあり、その場合にも対応済みです。
`abort`や`dict`の例は`:function`を実行すると確認できます (以下は私の環境で確認した関数定義の例です)。
- abort
  - `function <SNR>10_Vivo_disable(args) abort`
- dict
  - `function <SNR>425_BufferString_empty() dict`
- abort dict
  - `function <SNR>320__uri_is_port(str) abort dict`
