### PR TITLE
Add "scriptencoding utf-8"

### DIFF
--- a/autoload/vmock/container.vim
+++ b/autoload/vmock/container.vim
@@ -1,3 +1,4 @@
+scriptencoding utf-8
 " AUTHOR: kanno <akapanna@gmail.com>
 " License: This file is placed in the public domain.
 let s:save_cpo = &cpo

--- a/autoload/vmock/exception.vim
+++ b/autoload/vmock/exception.vim
@@ -1,3 +1,4 @@
+scriptencoding utf-8
 " AUTHOR: kanno <akapanna@gmail.com>
 " License: This file is placed in the public domain.
 let s:save_cpo = &cpo

--- a/autoload/vmock/expect.vim
+++ b/autoload/vmock/expect.vim
@@ -1,3 +1,4 @@
+scriptencoding utf-8
 " AUTHOR: kanno <akapanna@gmail.com>
 " License: This file is placed in the public domain.
 let s:save_cpo = &cpo

--- a/autoload/vmock/for_test/autoload_testdata.vim
+++ b/autoload/vmock/for_test/autoload_testdata.vim
@@ -1,3 +1,4 @@
+scriptencoding utf-8
 " AUTHOR: kanno <akapanna@gmail.com>
 " License: This file is placed in the public domain.
 

--- a/autoload/vmock/for_test/testdata.vim
+++ b/autoload/vmock/for_test/testdata.vim
@@ -1,3 +1,4 @@
+scriptencoding utf-8
 " AUTHOR: kanno <akapanna@gmail.com>
 " License: This file is placed in the public domain.
 

--- a/autoload/vmock/function_define.vim
+++ b/autoload/vmock/function_define.vim
@@ -1,3 +1,4 @@
+scriptencoding utf-8
 " AUTHOR: kanno <akapanna@gmail.com>
 " License: This file is placed in the public domain.
 let s:save_cpo = &cpo

--- a/autoload/vmock/matcher/count.vim
+++ b/autoload/vmock/matcher/count.vim
@@ -1,3 +1,4 @@
+scriptencoding utf-8
 " AUTHOR: kanno <akapanna@gmail.com>
 " License: This file is placed in the public domain.
 let s:save_cpo = &cpo

--- a/autoload/vmock/matcher/with.vim
+++ b/autoload/vmock/matcher/with.vim
@@ -1,3 +1,4 @@
+scriptencoding utf-8
 " AUTHOR: kanno <akapanna@gmail.com>
 " License: This file is placed in the public domain.
 let s:save_cpo = &cpo

--- a/autoload/vmock/matcher/with_group.vim
+++ b/autoload/vmock/matcher/with_group.vim
@@ -1,3 +1,4 @@
+scriptencoding utf-8
 " AUTHOR: kanno <akapanna@gmail.com>
 " License: This file is placed in the public domain.
 let s:save_cpo = &cpo

--- a/autoload/vmock/mock.vim
+++ b/autoload/vmock/mock.vim
@@ -1,3 +1,4 @@
+scriptencoding utf-8
 " AUTHOR: kanno <akapanna@gmail.com>
 " License: This file is placed in the public domain.
 let s:save_cpo = &cpo


### PR DESCRIPTION
`scriptencoding utf-8` の1行を各スクリプトの先頭に追加しました。

[AppVeyor](https://www.appveyor.com/) といった Windows 向けの CI サービスがあり、
この CI サービスの Windows 環境のロケールが英語になっています。
よってソースコード中に日本語コメント等のマルチバイト文字を含める場合は、
日本語ロケールでない環境も意識して `scriptencoding utf-8` をスクリプトの先頭に書く必要があります。
